### PR TITLE
groupTitle/update

### DIFF
--- a/backend/db/Column/patchColumn.js
+++ b/backend/db/Column/patchColumn.js
@@ -1,7 +1,7 @@
 const promisePool = require("../connection.js");
 
 function patchColumn(groupId, groupTitle) {
-  const query = `update TODOLIST set groupTitle='${groupTitle}' where groupId='${groupId}'`;
+  const query = `update TODOLIST set groupTitle='${groupTitle}' where groupId='todoList-${groupId}'`;
   return promisePool.execute(query);
 }
 

--- a/backend/db/Column/patchColumn.js
+++ b/backend/db/Column/patchColumn.js
@@ -1,0 +1,8 @@
+const promisePool = require("../connection.js");
+
+function patchColumn(groupId, groupTitle) {
+  const query = `update TODOLIST set groupTitle='${groupTitle}' where groupId='${groupId}'`;
+  return promisePool.execute(query);
+}
+
+module.exports = patchColumn;

--- a/backend/functions/column.js
+++ b/backend/functions/column.js
@@ -21,9 +21,10 @@ async function patchColumnsCallback(req, res) {
     const groupId = req.params.groupId;
     const groupTitle = req.body.groupTitle;
     const result = await patchColumn(groupId, groupTitle);
-    if (result[0].affectedRows !== 1) throw new Error();
+    if (result[0].affectedRows < 1) throw new Error();
     return res.sendStatus(statusCode.OK);
   } catch (e) {
+    console.log(e);
     return res.status(statusCode.DB_ERROR).send(errorMessage.DB_ERROR);
   }
 }

--- a/backend/functions/column.js
+++ b/backend/functions/column.js
@@ -1,4 +1,5 @@
 const getColumns = require("../db/Column/getColumn.js");
+const patchColumn = require("../db/Column/patchColumn.js");
 
 const statusCode = require("../utils/statusCode.js");
 const errorMessage = require("../utils/errorMessage.js");
@@ -15,4 +16,16 @@ async function getColumnsCallback(req, res) {
   }
 }
 
-module.exports = { getColumnsCallback };
+async function patchColumnsCallback(req, res) {
+  try {
+    const groupId = req.params.groupId;
+    const groupTitle = req.body.groupTitle;
+    const result = await patchColumn(groupId, groupTitle);
+    if (result[0].affectedRows !== 1) throw new Error();
+    return res.sendStatus(statusCode.OK);
+  } catch (e) {
+    return res.status(statusCode.DB_ERROR).send(errorMessage.DB_ERROR);
+  }
+}
+
+module.exports = { getColumnsCallback, patchColumnsCallback };

--- a/backend/functions/todo.js
+++ b/backend/functions/todo.js
@@ -56,16 +56,6 @@ async function deleteTodoCallback(req, res) {
   }
 }
 
-// async function getTodoCountCallback(req, res) {
-//   try {
-//     const result = await getTodoCount();
-//     const count = result[0].length;
-//     return res.status(statusCode.OK).json(count);
-//   } catch (e) {
-//     return res.status(statusCode.DB_ERROR).send(errorMessage.DB_ERROR);
-//   }
-// }
-
 async function patchTodoCallback(req, res) {
   const { title, content, author } = req.body;
   const id = req.params.id;

--- a/backend/routes/column.js
+++ b/backend/routes/column.js
@@ -1,9 +1,13 @@
 const express = require("express");
 const router = express.Router();
 
-const { getColumnsCallback } = require("../functions/column.js");
+const {
+  getColumnsCallback,
+  patchColumnsCallback,
+} = require("../functions/column.js");
 // /api/columns
 // router.get("/count", getTodoCountCallback);
 router.get("/", getColumnsCallback);
+router.patch("/:groupId", patchColumnsCallback);
 
 module.exports = router;

--- a/frontend/src/components/main.js
+++ b/frontend/src/components/main.js
@@ -2,8 +2,8 @@ import { getFetchManger } from '../modules/utils/fetchManger.js';
 import Container from './container.js';
 import Item from './item.js';
 import 'regenerator-runtime/runtime';
-import addTodo from '../modules/addTodo.js';
-import deleteTodo from '../modules/deleteTodo.js';
+import addTodo from '../modules/todo/addTodo.js';
+import deleteTodo from '../modules/todo/deleteTodo.js';
 import { todoApi, columnApi } from '../modules/utils/routerList.js';
 
 export default class Main {

--- a/frontend/src/modules/column/patchColumn.js
+++ b/frontend/src/modules/column/patchColumn.js
@@ -1,0 +1,12 @@
+import { patchFetchManger } from '../utils/fetchManger.js';
+import { columnApi } from '../utils/routerList.js';
+
+export default async function patchColumn(body, groupId) {
+  try {
+    const result = await patchFetchManger(`${columnApi}/${groupId}`, body);
+    if (result.status !== 200) throw new Error();
+    return true;
+  } catch (e) {
+    alert('다시 해주세요');
+  }
+}

--- a/frontend/src/modules/modal.js
+++ b/frontend/src/modules/modal.js
@@ -1,5 +1,5 @@
 import splitText from './utils/splitText.js';
-import patchTodo from './patchTodo.js';
+import patchTodo from '../modules/todo/patchTodo.js';
 
 export function toggleModal() {
   const modal = document.querySelector('.modal');

--- a/frontend/src/modules/modal.js
+++ b/frontend/src/modules/modal.js
@@ -1,5 +1,6 @@
 import splitText from './utils/splitText.js';
-import patchTodo from '../modules/todo/patchTodo.js';
+import patchTodo from './todo/patchTodo.js';
+import patchColumn from './column/patchColumn.js';
 
 export function toggleModal() {
   const modal = document.querySelector('.modal');
@@ -7,6 +8,7 @@ export function toggleModal() {
   const columnModal = modal.children[1];
   let targetElement;
   let liId;
+  let groupId;
 
   modal.addEventListener('click', closeHandler);
   modal.addEventListener('click', contentUpdateHandler);
@@ -35,10 +37,13 @@ export function toggleModal() {
     targetElement.querySelector('.todo-item-content > p').textContent = content;
   }
 
-  function columnUpdateHandler(e) {
+  async function columnUpdateHandler(e) {
     if (e.target.dataset.id !== 'modal-column-update') return;
     const textArea = e.target.previousElementSibling;
-    targetElement.textContent = textArea.value;
+    const groupTitle = textArea.value;
+    const result = await patchColumn({ groupTitle }, groupId);
+    if (!result) return;
+    targetElement.textContent = groupTitle;
     textArea.value = '';
     closeModal(e);
   }
@@ -46,8 +51,8 @@ export function toggleModal() {
   function showContentModalHandler(e) {
     // console.log(liId);
     const li = e.target.closest('li');
-    liId = li.getAttribute('id');
     if (!li || li.className !== 'todo-item') return;
+    liId = li.getAttribute('id');
     targetElement = li;
     contentModal.classList.remove('hidden');
     contentModal.querySelector('textarea').value =
@@ -58,6 +63,7 @@ export function toggleModal() {
   function showColumnModalHandler(e) {
     if (e.target.className !== 'todo-container-header-title') return;
     const currentModal = modal.children[1];
+    groupId = e.target.id.substr(13);
     targetElement = e.target;
     columnModal.classList.remove('hidden');
     columnModal.querySelector('input[type="text"]').value =

--- a/frontend/src/modules/modal.js
+++ b/frontend/src/modules/modal.js
@@ -49,25 +49,37 @@ export function toggleModal() {
   }
 
   function showContentModalHandler(e) {
-    // console.log(liId);
     const li = e.target.closest('li');
     if (!li || li.className !== 'todo-item') return;
     liId = li.getAttribute('id');
     targetElement = li;
-    contentModal.classList.remove('hidden');
-    contentModal.querySelector('textarea').value =
+    renderContentModal(li);
+  }
+
+  function renderContentModal(li) {
+    const textArea = contentModal.querySelector('textarea');
+    const content =
       li.querySelector('.todo-item-title').textContent +
       li.querySelector('.todo-item-content').textContent;
+    renderModal(contentModal, textArea, content);
   }
 
   function showColumnModalHandler(e) {
     if (e.target.className !== 'todo-container-header-title') return;
-    const currentModal = modal.children[1];
     groupId = e.target.id.substr(13);
     targetElement = e.target;
-    columnModal.classList.remove('hidden');
-    columnModal.querySelector('input[type="text"]').value =
-      e.target.textContent;
+    renderColumnModal(e);
+  }
+
+  function renderColumnModal(e) {
+    const inputText = columnModal.querySelector('input[type="text"]');
+    renderModal(columnModal, inputText, e.target.textContent);
+  }
+
+  function renderModal(modal, element, content) {
+    modal.classList.remove('hidden');
+    element.value = content;
+    element.select();
   }
 
   function closeModal(e) {

--- a/frontend/src/modules/todo/addTodo.js
+++ b/frontend/src/modules/todo/addTodo.js
@@ -1,8 +1,8 @@
-import Item from '../components/item';
-import { postFetchManger } from './utils/fetchManger.js';
-import { todoApi } from './utils/routerList.js';
-import { updateCount } from './utils/updateCount.js';
-import splitText from './utils/splitText.js';
+import Item from '../../components/item';
+import { postFetchManger } from '../utils/fetchManger.js';
+import { todoApi } from '../utils/routerList.js';
+import { updateCount } from '../utils/updateCount.js';
+import splitText from '../utils/splitText.js';
 
 export default async function addTodo(e) {
   //add버튼을 눌렀을 때만 동작

--- a/frontend/src/modules/todo/deleteTodo.js
+++ b/frontend/src/modules/todo/deleteTodo.js
@@ -1,6 +1,6 @@
-import { deleteFetchManager } from './utils/fetchManger.js';
-import { updateCount } from './utils/updateCount.js';
-import { todoApi, columnApi } from './utils/routerList.js';
+import { deleteFetchManager } from '../utils/fetchManger.js';
+import { updateCount } from '../utils/updateCount.js';
+import { todoApi, columnApi } from '../utils/routerList.js';
 const confirmSentence = '선택하신 카드를 삭제하겠습니까?';
 export default async function deleteTodo(e) {
   if (e.target.dataset.method !== 'delete') return;

--- a/frontend/src/modules/todo/patchTodo.js
+++ b/frontend/src/modules/todo/patchTodo.js
@@ -1,5 +1,6 @@
-import { patchFetchManger } from './utils/fetchManger.js';
-import { todoApi } from './utils/routerList.js';
+import { patchFetchManger } from '../utils/fetchManger.js';
+import { todoApi } from '../utils/routerList.js';
+
 export default async function patchTodo(body, id) {
   try {
     const result = await patchFetchManger(`${todoApi}/${id}`, body);


### PR DESCRIPTION
## [backend] groupTitle patch api 완성
* /api/columns/:groupId로 요청이 오면 해당 groupId의 groupTitle를 req.body.groupTitle로 업데이트하는 api 완성
* api에 필요한 쿼리문 완성

## modules/todo 폴더 생성
* todo와 관련된 module이 많아졌기 때문에 todo라는 폴더를 따로 생성하여 그 안에 넣었다.
* column과 관련된 모듈은 column이라는 폴더를 또 새로 만들어 넣을 것을 추천
* 결국 폴더 구조는 modules/todo/... 이다

## [updatColumn] front & back 연결
* column 제목을 업데이트하면 PATCH /api/columns/:groupId에 요청을 보내 정상적으로 수행되면 front에서도 업데이트
* 필요없는 주석 삭제

## modal rendering 리팩토링 

* modal를 rendering하는 로직을 공통화해 하나의 함수로 만듬
  * renderModal
* 모달이 뜨면 기존 내용이 다 선택된채로
  * select()  api 사용

closes #111 