### PR TITLE
Front/api/post/log

### DIFF
--- a/backend/functions/todoLog.js
+++ b/backend/functions/todoLog.js
@@ -22,7 +22,10 @@ async function postLogsCallback(req, res) {
     const log = req.body;
     const result = await insertTodoLog(log);
     if (result[0].affectedRows !== 1) throw new Error();
-    return res.sendStatus(statusCode.OK);
+    const response = {
+      id: result[0].insertId,
+    };
+    return res.status(statusCode.OK).json(response);
   } catch (e) {
     return res.status(statusCode.DB_ERROR).send(errorMessage.DB_ERROR);
   }

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -7,7 +7,7 @@ import 'regenerator-runtime/runtime';
 import { toggleInput } from './modules/toggleInput.js';
 import { toggleBtn } from './modules/toggleBtn';
 import { toggleModal } from './modules/modal';
-import { openSidebar, closeSidebar } from './modules/sidebar';
+import sidebar from './modules/sidebar';
 // import { dragAndDrop } from './modules/dragAndDrop';
 
 window.addEventListener('DOMContentLoaded', async () => {
@@ -21,6 +21,5 @@ window.addEventListener('DOMContentLoaded', async () => {
   toggleInput();
   toggleBtn();
   toggleModal();
-  openSidebar();
-  closeSidebar();
+  sidebar();
 });

--- a/frontend/src/modules/modal.js
+++ b/frontend/src/modules/modal.js
@@ -25,16 +25,14 @@ export function toggleModal() {
     if (e.target.dataset.id !== 'modal-content-update') return;
     const textArea = e.target.previousElementSibling;
     const { title, content } = splitText(textArea.value);
-    const result = await patchTodo({ title, content, author: 'cc6656' }, liId);
+    const result = await patchTodo(
+      { title, content, author: 'cc6656' },
+      liId,
+      targetElement,
+    );
     if (!result) return;
-    updateContentText(title, content);
     textArea.value = '';
     closeModal(e);
-  }
-
-  function updateContentText(title, content) {
-    targetElement.querySelector('.todo-item-title').textContent = title;
-    targetElement.querySelector('.todo-item-content > p').textContent = content;
   }
 
   async function columnUpdateHandler(e) {

--- a/frontend/src/modules/sidebar.js
+++ b/frontend/src/modules/sidebar.js
@@ -1,17 +1,19 @@
-const sidebar = document.querySelector('.sidebar');
+export default function sidebar() {
+  const sidebar = document.querySelector('.sidebar');
+  openSidebar();
+  closeSidebar();
 
-function openSidebar() {
-  const menuBtn = document.querySelector('.menu-btn');
-  menuBtn.addEventListener('click', () => {
-    sidebar.classList.remove('hidden');
-  });
+  function openSidebar() {
+    const menuBtn = document.querySelector('.menu-btn');
+    menuBtn.addEventListener('click', () => {
+      sidebar.classList.remove('hidden');
+    });
+  }
+
+  function closeSidebar() {
+    const closeBtn = sidebar.querySelector('#sidebar-close');
+    closeBtn.addEventListener('click', () => {
+      sidebar.classList.add('hidden');
+    });
+  }
 }
-
-function closeSidebar() {
-  const closeBtn = sidebar.querySelector('#sidebar-close');
-  closeBtn.addEventListener('click', () => {
-    sidebar.classList.add('hidden');
-  });
-}
-
-export { openSidebar, closeSidebar };

--- a/frontend/src/modules/todo/addTodo.js
+++ b/frontend/src/modules/todo/addTodo.js
@@ -20,20 +20,26 @@ export default async function addTodo(e) {
   const data = makeData({ listUl, inputUl, groupId, textarea });
 
   await addItem(data);
-  const log = {
-    username: 'cc6656',
-    actionType: actionTypeList.ADD,
-    time: new Date().toString(),
-    presentContent: data.title,
-    presentColumn: data.groupTitle,
-  };
   clearTextarea(textarea);
 
   fillTitleContent(listUl, data);
   const count = listUl.querySelectorAll('li').length;
   updateCount(listUl);
 
+  const log = makeAddLog(data.title, data.groupTitle);
   addTodoLog(log);
+}
+
+function makeAddLog(title, groupTitle) {
+  return {
+    username: 'cc6656',
+    actionType: actionTypeList.ADD,
+    time: new Date().toString(),
+    previousContent: null,
+    presentContent: title,
+    previousColumn: null,
+    presentColumn: groupTitle,
+  };
 }
 
 function clearTextarea(textarea) {

--- a/frontend/src/modules/todo/addTodo.js
+++ b/frontend/src/modules/todo/addTodo.js
@@ -3,6 +3,8 @@ import { postFetchManger } from '../utils/fetchManger.js';
 import { todoApi } from '../utils/routerList.js';
 import { updateCount } from '../utils/updateCount.js';
 import splitText from '../utils/splitText.js';
+import { addTodoLog } from '../todoLog.js';
+import actionTypeList from '../utils/actionTypeList.js';
 
 export default async function addTodo(e) {
   //add버튼을 눌렀을 때만 동작
@@ -18,11 +20,20 @@ export default async function addTodo(e) {
   const data = makeData({ listUl, inputUl, groupId, textarea });
 
   await addItem(data);
+  const log = {
+    username: 'cc6656',
+    actionType: actionTypeList.ADD,
+    time: new Date().toString(),
+    presentContent: data.title,
+    presentColumn: data.groupTitle,
+  };
   clearTextarea(textarea);
 
   fillTitleContent(listUl, data);
   const count = listUl.querySelectorAll('li').length;
   updateCount(listUl);
+
+  addTodoLog(log);
 }
 
 function clearTextarea(textarea) {
@@ -49,12 +60,21 @@ function makeData({ listUl, inputUl, groupId, textarea }) {
   return data;
 }
 
-async function addItem(data) {
-  const result = await postFetchManger(todoApi, data);
-  const id = result.id;
-  const item = new Item();
-  data.id = id;
-  item.addItem(data);
+function addItem(data) {
+  postFetchManger(todoApi, data)
+    .then((res) => {
+      if (res.status !== 200) throw new Error();
+      return res.json();
+    })
+    .then((result) => {
+      const id = result.id;
+      const item = new Item();
+      data.id = id;
+      item.addItem(data);
+    })
+    .catch((e) => {
+      alert('다시 해주세요');
+    });
 }
 
 function fillTitleContent(listUl, { title, content }) {

--- a/frontend/src/modules/todo/deleteTodo.js
+++ b/frontend/src/modules/todo/deleteTodo.js
@@ -1,12 +1,21 @@
 import { deleteFetchManager } from '../utils/fetchManger.js';
 import { updateCount } from '../utils/updateCount.js';
-import { todoApi, columnApi } from '../utils/routerList.js';
+import { todoApi } from '../utils/routerList.js';
+
+import { addTodoLog } from '../todoLog.js';
+import actionTypeList from '../utils/actionTypeList.js';
+
 const confirmSentence = '선택하신 카드를 삭제하겠습니까?';
+
 export default async function deleteTodo(e) {
   if (e.target.dataset.method !== 'delete') return;
   if (!checkConfirm()) return;
 
   const deleteItem = e.target.closest('li');
+  const title = deleteItem.querySelector('.todo-item-title').textContent;
+  const groupTitle = deleteItem
+    .closest('section')
+    .querySelector('.todo-container-header-title').textContent;
   const id = deleteItem.id;
   const ul = e.target.closest('ul');
 
@@ -15,9 +24,23 @@ export default async function deleteTodo(e) {
     if (result.status !== 200) throw new Error();
     deleteItem.remove();
     updateCount(ul);
+    const log = makeRemoveLog(title, groupTitle);
+    addTodoLog(log);
   } catch (e) {
     alert('다시 시도해주세요');
   }
+}
+
+function makeRemoveLog(title, groupTitle) {
+  return {
+    username: 'cc6656',
+    actionType: actionTypeList.REMOVE,
+    time: new Date().toString(),
+    previousContent: null,
+    presentContent: title,
+    previousColumn: null,
+    presentColumn: groupTitle,
+  };
 }
 
 function checkConfirm() {

--- a/frontend/src/modules/todo/patchTodo.js
+++ b/frontend/src/modules/todo/patchTodo.js
@@ -14,7 +14,7 @@ export default async function patchTodo(body, id, targetElement) {
 
     updateContentText(targetElement, title, content);
 
-    const log = makeUpdateLog(previousContent, content);
+    const log = makeUpdateLog(previousContent, title);
     addTodoLog(log);
     return true;
   } catch (e) {
@@ -30,7 +30,7 @@ function updateContentText(targetElement, title, content) {
 function makeUpdateLog(previousContent, presentContent) {
   return {
     username: 'cc6656',
-    actionType: actionTypeList.REMOVE,
+    actionType: actionTypeList.UPDATE,
     time: new Date().toString(),
     previousContent,
     presentContent,

--- a/frontend/src/modules/todo/patchTodo.js
+++ b/frontend/src/modules/todo/patchTodo.js
@@ -1,12 +1,40 @@
 import { patchFetchManger } from '../utils/fetchManger.js';
 import { todoApi } from '../utils/routerList.js';
 
-export default async function patchTodo(body, id) {
+import { addTodoLog } from '../todoLog.js';
+import actionTypeList from '../utils/actionTypeList.js';
+
+export default async function patchTodo(body, id, targetElement) {
   try {
     const result = await patchFetchManger(`${todoApi}/${id}`, body);
     if (result.status !== 200) throw new Error();
+    const { title, content, author } = body;
+    const previousContent = targetElement.querySelector('.todo-item-title')
+      .textContent;
+
+    updateContentText(targetElement, title, content);
+
+    const log = makeUpdateLog(previousContent, content);
+    addTodoLog(log);
     return true;
   } catch (e) {
     alert('다시 해주세요');
   }
+}
+
+function updateContentText(targetElement, title, content) {
+  targetElement.querySelector('.todo-item-title').textContent = title;
+  targetElement.querySelector('.todo-item-content > p').textContent = content;
+}
+
+function makeUpdateLog(previousContent, presentContent) {
+  return {
+    username: 'cc6656',
+    actionType: actionTypeList.REMOVE,
+    time: new Date().toString(),
+    previousContent,
+    presentContent,
+    previousColumn: null,
+    presentColumn: null,
+  };
 }

--- a/frontend/src/modules/todoLog.js
+++ b/frontend/src/modules/todoLog.js
@@ -1,0 +1,82 @@
+import { postFetchManger } from './utils/fetchManger.js';
+import { todoLogApi } from './utils/routerList.js';
+
+function addTodoLog(data) {
+  const logUl = document.querySelector('ul.activity-ul');
+  postFetchManger(todoLogApi, data)
+    .then((res) => {
+      if (res.status !== 200) throw new Error();
+      return res.json();
+    })
+    .then((res) => {
+      const todoLog = makeTodoLog(data);
+      logUl.insertAdjacentHTML('afterbegin', todoLog);
+    })
+    .catch((e) => {
+      console.log(e);
+    });
+}
+
+export { addTodoLog };
+
+function makeTodoLog(data) {
+  const {
+    actionType,
+    username,
+    previousContent,
+    presentContent,
+    preivousColumn,
+    presentColumn,
+  } = data;
+
+  const time = calculateTime(data.time);
+  let content;
+
+  switch (actionType) {
+    case 'add':
+      content = `added ${presentContent} to ${presentColumn}`;
+      break;
+    case 'remove':
+      content = `removed ${presentContent} from ${presentColumn}`;
+      break;
+    case 'update':
+      content = `updated ${previousContent} to ${presentContent}`;
+      break;
+    case 'move':
+      content = `moved ${presentContent} from ${preivousColumn} to ${presentColumn}`;
+      break;
+    default:
+  }
+  return makeTemplate(username, content, time);
+}
+
+function calculateTime(pastTimeString) {
+  const millisecondUnit = 1000;
+  const timeUnit = 60;
+  const dateUnit = 24;
+
+  const presentTime = new Date();
+  const pastTime = new Date(pastTimeString);
+
+  const diffSecond = Math.floor((presentTime - pastTime) / millisecondUnit);
+  const diffMinute = Math.floor(diffSecond / timeUnit);
+  const diffHour = Math.floor(diffMinute / timeUnit);
+  const diffDate = Math.floor(diffHour / dateUnit);
+
+  if (diffDate > 0) return `${diffDate} days`;
+  else if (diffHour > 0) return `${diffHour} hours`;
+  else if (diffMinute > 0) return `${diffMinute} hours`;
+  else return `${diffSecond} seconds`;
+}
+
+function makeTemplate(username, content, time) {
+  return `<li>
+    <div class="row">
+    <img src="https://images.unsplash.com/photo-1537151608828-ea2b11777ee8?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1239&q=80" alt="logo" style="width:40px;height:40px">
+    <div class="col">
+        <div class="log"><p>@${username}</p> ${content} </div>
+        <div><span class="time">${time}</span> ago.</div>
+    </div>
+    </div>
+  </li>`;
+}

--- a/frontend/src/modules/utils/actionTypeList.js
+++ b/frontend/src/modules/utils/actionTypeList.js
@@ -1,0 +1,6 @@
+export default {
+  ADD: 'add',
+  MOVE: 'move',
+  UPDATE: 'update',
+  REMOVE: 'remove',
+};

--- a/frontend/src/modules/utils/fetchManger.js
+++ b/frontend/src/modules/utils/fetchManger.js
@@ -18,9 +18,7 @@ function getFetchManger(url) {
 
 function postFetchManger(url, body) {
   postOptions['body'] = JSON.stringify(body);
-  return fetch(baseUrl + url, postOptions)
-    .then((res) => res.json())
-    .catch((e) => console.log(e));
+  return fetch(baseUrl + url, postOptions);
 }
 
 function deleteFetchManager(url) {

--- a/frontend/src/modules/utils/routerList.js
+++ b/frontend/src/modules/utils/routerList.js
@@ -1,4 +1,4 @@
 const todoApi = '/api/todos';
 const columnApi = '/api/columns';
-
-export { todoApi, columnApi };
+const todoLogApi = '/api/todo-logs';
+export { todoApi, columnApi, todoLogApi };


### PR DESCRIPTION
# addTodo, deleteTodo, patchTodo할 시 해당 내용이 로그에 기록되도록
  * api를 통해 db에 저장후 화면에 렌더링 

### patchTodo, modal.js 수정 
* patchTodo의 경우 addTodo, deleteTodo와 달리 대부분의 로직이 modal.js에 있다.
* 따라서, log를 추가하는 로직 또한 modal 안에 추가해야하는 현상 발생
* 하지만 이는 통일성이 없고 modal이 자기와 무관한 업무를 맡는 문제를 갖는다.
* 따라서 기존의 modal과 patchTodo를 수정했다.
  * patchTodo에서 더 많은 일을 하도록
  * 화면에 업데이트하는 부분도 patchTodo가 담당하도록 변경
* log에 추가하는 로직 또한 PatchTodo에서 담당

### actionTypeList 추가 
* 매직 넘버, 문자열을 없애기 위해서 log에 들어가는 actionType을 정의해 놓은 객체를 만들었다.
* 이후 해당 객체를 import해서 접근하면 된다.

### fetachManger 수정
* res.json() 삭제
* 기존에는 fetchManger에서 res.json()까지 해주고 promise를 반환하면 로직이 간단해질 것이라고 기대
* 하지만 실제로는 json을 response로 주지 않는 api도 있기 때문에 없는 편이 더 낫다.
* 따라서 res.json()은 fetchManger를 실행하는 함수에서 실시하도록 변경