### PR TITLE
dragdrop에 필요한 /api/todos/move/:id 완성

### DIFF
--- a/backend/db/Todo/updateTodoPosition.js
+++ b/backend/db/Todo/updateTodoPosition.js
@@ -1,0 +1,13 @@
+const promisePool = require("../connection.js");
+
+function idxUpdateTodos({ groupId, idx }) {
+  const query = `UPDATE TODOLIST SET idx=idx+1 WHERE groupId='${groupId}' and idx>=${idx}`;
+  return promisePool.execute(query);
+}
+
+function idxUpdate({ groupId, idx, id }) {
+  const query = `UPDATE TODOLIST SET idx=${idx}, groupId='${groupId}' WHERE id=${id}`;
+  return promisePool.execute(query);
+}
+
+module.exports = { idxUpdate, idxUpdateTodos };

--- a/backend/functions/todo.js
+++ b/backend/functions/todo.js
@@ -2,9 +2,30 @@ const getTodoDB = require("../db/Todo/getTodoList.js");
 const insertTodo = require("../db/Todo/insertTodo.js");
 const deleteTodo = require("../db/Todo/deleteTodo.js");
 const updateTodo = require("../db/Todo/updateTodo.js");
-
+const {
+  idxUpdate,
+  idxUpdateTodos,
+} = require("../db/Todo/updateTodoPosition.js");
 const statusCode = require("../utils/statusCode.js");
 const errorMessage = require("../utils/errorMessage.js");
+
+function patchMoveTodoCallback(req, res) {
+  const id = req.params.id;
+  const { idx, groupId } = req.body;
+
+  idxUpdateTodos({ groupId, idx })
+    .then((result) => {
+      if (result[0].affectedRows === 0) throw new Error();
+      return idxUpdate({ groupId, idx, id });
+    })
+    .then((result) => {
+      if (result[0].affectedRows === 0) throw new Error();
+      return res.sendStatus(statusCode.OK);
+    })
+    .catch((e) => {
+      return res.status(statusCode.DB_ERROR).send(errorMessage.DB_ERROR);
+    });
+}
 
 async function getTodoCallback(req, res) {
   try {
@@ -74,4 +95,5 @@ module.exports = {
   validateTodo,
   deleteTodoCallback,
   patchTodoCallback,
+  patchMoveTodoCallback,
 };

--- a/backend/routes/todo.js
+++ b/backend/routes/todo.js
@@ -7,7 +7,7 @@ const {
   validateTodo,
   deleteTodoCallback,
   patchTodoCallback,
-  distinctColumnsCallback,
+  patchMoveTodoCallback,
 } = require("../functions/todo.js");
 // api 서버
 
@@ -15,5 +15,7 @@ router.get("/", getTodoCallback);
 router.post("/", validateTodo, postTodoCallback);
 router.delete("/:id", deleteTodoCallback);
 router.patch("/:id", patchTodoCallback);
+
+router.patch("/move/:id", patchMoveTodoCallback);
 
 module.exports = router;


### PR DESCRIPTION
* PATCH /api/todos/move/:id
* 먼저 request의 idx 이상의 todo들의 idx를 +1 시키다.
* 그 다음 해당 id의 todo의 idx를 request의 idx로 업데이트
* 두개의 쿼리문 사용(비동기 처리)
* 해당 비동기처리는 promise 패턴을 이용하였다.
* postman을 통한 test 완료